### PR TITLE
Add WebMIDI support

### DIFF
--- a/docs/audio/synthesized-sound.md
+++ b/docs/audio/synthesized-sound.md
@@ -668,4 +668,32 @@ A more complicated example that has the drum pattern fall over two measures of 2
 
 Note that the default soundfont that is used by abcjs contains sounds for pitches **27** through **87**. You can experiment with any of them for different effects.
 
+## WebMIDI Playback
+
+abcjs also supports playing a tune through any WebMIDI output. Use the `WebMidiPlayer` class:
+
+```javascript
+var player = new ABCJS.synth.WebMidiPlayer();
+player.init({ visualObj: visualObj }).then(function(){
+  var outs = player.getOutputs(); // array of MIDIOutput
+  if (outs.length) {
+    player.setOutput(outs[0].id); // choose a device
+    player.start();
+  }
+});
+```
+
+To capture live input and insert notes into an `ABCJS.Editor`, use `MidiInputHandler`:
+
+```javascript
+var input = new ABCJS.synth.MidiInputHandler(editor);
+input.init().then(function(){
+  var devices = input.getInputs();
+  if (devices.length)
+    input.setInput(devices[0].id);
+});
+```
+
+Incoming `noteon` events will be translated to simple ABC note names and placed at the current cursor position.
+
 

--- a/index.js
+++ b/index.js
@@ -59,6 +59,8 @@ var playEvent = require('./src/synth/play-event');
 var SynthController = require('./src/synth/synth-controller');
 var getMidiFile = require('./src/synth/get-midi-file');
 var midiRenderer = require('./src/synth/abc_midi_renderer');
+var WebMidiPlayer = require('./src/synth/webmidi-player');
+var MidiInputHandler = require('./src/synth/midi-input-handler');
 
 abcjs.synth = {
 	CreateSynth: CreateSynth,
@@ -72,8 +74,10 @@ abcjs.synth = {
 	supportsAudio: supportsAudio,
 	playEvent: playEvent,
 	getMidiFile: getMidiFile,
-	sequence: sequence,
-	midiRenderer: midiRenderer,
+        sequence: sequence,
+        midiRenderer: midiRenderer,
+        WebMidiPlayer: WebMidiPlayer,
+        MidiInputHandler: MidiInputHandler
 };
 
 abcjs['Editor'] = require('./src/edit/abc_editor');

--- a/src/edit/abc_editarea.js
+++ b/src/edit/abc_editarea.js
@@ -104,11 +104,27 @@ EditArea.prototype.getString = function () {
 };
 
 EditArea.prototype.setString = function (str) {
-	this.textarea.value = str;
-	this.initialText = this.getString();
-	if (this.changelistener) {
-		this.changelistener.fireChanged();
-	}
+        this.textarea.value = str;
+        this.initialText = this.getString();
+        if (this.changelistener) {
+                this.changelistener.fireChanged();
+        }
+};
+
+// Insert text at the current cursor position. This is useful when
+// feeding characters from an external MIDI device into the editor.
+// The change listener is notified so the editor can re-render.
+EditArea.prototype.insertAtCursor = function(str) {
+        var start = this.textarea.selectionStart;
+        var end = this.textarea.selectionEnd;
+        var current = this.textarea.value;
+        this.textarea.value = current.substring(0, start) + str + current.substring(end);
+        var pos = start + str.length;
+        if (this.textarea.setSelectionRange)
+                this.textarea.setSelectionRange(pos, pos);
+        this.textarea.focus();
+        if (this.changelistener)
+                this.changelistener.fireChanged();
 };
 
 EditArea.prototype.getElem = function () {

--- a/src/synth/midi-input-handler.js
+++ b/src/synth/midi-input-handler.js
@@ -1,0 +1,60 @@
+// Helper class to route note on events from a MIDI input device into the
+// ABC editor. This provides a very simple mapping from MIDI note numbers to
+// ABC note names and inserts them at the current cursor position.
+
+var pitchToNoteName = require('./pitch-to-note-name');
+
+function noteNameToAbc(name) {
+    var letter = name[0];
+    var accidental = name.length === 3 ? name[1] : '';
+    var octave = parseInt(name[name.length - 1], 10);
+    var acc = '';
+    if (accidental === 'b') acc = '_';
+    if (accidental === '#') acc = '^';
+    var diff = octave - 4;
+    var base = diff > 0 ? letter.toLowerCase() : letter.toUpperCase();
+    var marks = '';
+    if (diff > 0) marks = Array(diff).fill("'").join('');
+    if (diff < 0) marks = Array(-diff).fill(',').join('');
+    return acc + base + marks;
+}
+
+function MidiInputHandler(editor) {
+    var self = this;
+    self.editor = editor;
+    self.midiAccess = null;
+    self.input = null;
+
+    self.init = function() {
+        return navigator.requestMIDIAccess().then(function(access){
+            self.midiAccess = access;
+            return {status:'ok'};
+        });
+    };
+
+    self.getInputs = function() {
+        if (!self.midiAccess) return [];
+        return Array.from(self.midiAccess.inputs.values());
+    };
+
+    self.setInput = function(id) {
+        if (!self.midiAccess) return;
+        if (self.input) self.input.onmidimessage = null;
+        self.input = self.midiAccess.inputs.get(id);
+        if (self.input) {
+            self.input.onmidimessage = function(ev) {
+                var data = ev.data;
+                if (!data || data.length < 3) return;
+                if ((data[0] & 0xf0) === 0x90 && data[2] > 0) {
+                    var name = pitchToNoteName[data[1]];
+                    if (!name) return;
+                    var abc = noteNameToAbc(name) + ' ';
+                    if (self.editor && self.editor.editarea && self.editor.editarea.insertAtCursor)
+                        self.editor.editarea.insertAtCursor(abc);
+                }
+            };
+        }
+    };
+}
+
+module.exports = MidiInputHandler;

--- a/src/synth/webmidi-player.js
+++ b/src/synth/webmidi-player.js
@@ -1,0 +1,73 @@
+// Simple WebMIDI player that sends the note events from a tune to a
+// selected MIDI output device.
+
+var createNoteMap = require('./create-note-map');
+
+function WebMidiPlayer() {
+    var self = this;
+    self.midiAccess = null;
+    self.output = null;
+    self.noteMapTracks = null;
+    self.millisecondsPerMeasure = 1000;
+    self.meterSize = 1;
+
+    // Initialize with the visualObj (from renderAbc) or a sequence as CreateSynth does.
+    self.init = function(options) {
+        if (!options) options = {};
+        var visualObj = options.visualObj;
+        var sequence = options.sequence;
+        if (visualObj) {
+            self.flattened = visualObj.setUpAudio(options.options || {});
+            self.millisecondsPerMeasure = options.millisecondsPerMeasure ? options.millisecondsPerMeasure : visualObj.millisecondsPerMeasure(self.flattened.tempo);
+            self.meterSize = visualObj.getMeterFraction().num / visualObj.getMeterFraction().den;
+        } else if (sequence) {
+            self.flattened = sequence;
+        } else {
+            return Promise.reject(new Error('Must pass in either a visualObj or a sequence'));
+        }
+        self.noteMapTracks = createNoteMap(self.flattened);
+        return navigator.requestMIDIAccess().then(function(access){
+            self.midiAccess = access;
+            return {status:'ok'};
+        });
+    };
+
+    self.getOutputs = function() {
+        if (!self.midiAccess) return [];
+        return Array.from(self.midiAccess.outputs.values());
+    };
+
+    self.setOutput = function(id) {
+        if (!self.midiAccess) return;
+        self.output = self.midiAccess.outputs.get(id);
+    };
+
+    function scheduleNote(note, tempoMultiplier) {
+        var start = note.start * tempoMultiplier * 1000;
+        var duration = (note.end - note.start) * tempoMultiplier * 1000;
+        setTimeout(function() {
+            if (!self.output) return;
+            self.output.send([0x90, note.pitch, note.volume]);
+            self.output.send([0x80, note.pitch, 0], window.performance.now() + duration);
+        }, start);
+    }
+
+    self.start = function() {
+        if (!self.output) return Promise.reject(new Error('No MIDI output selected'));
+        var tempoMultiplier = self.millisecondsPerMeasure / 1000 / self.meterSize;
+        self.noteMapTracks.forEach(function(track){
+            track.forEach(function(note){
+                scheduleNote(note, tempoMultiplier);
+            });
+        });
+        return Promise.resolve({status:'playing'});
+    };
+
+    self.stop = function() {
+        if (self.output) {
+            self.output.send([0xB0, 123, 0]); // all notes off
+        }
+    };
+}
+
+module.exports = WebMidiPlayer;


### PR DESCRIPTION
## Summary
- expose WebMidiPlayer and MidiInputHandler
- allow inserting text at the cursor
- document WebMIDI playback and MIDI input

## Testing
- `npm run test` *(fails: opener cannot launch browser)*

------
https://chatgpt.com/codex/tasks/task_e_686b6a47ba9c83318c820203844beb2b